### PR TITLE
Do not interpret shell metacharacters in tarFie when execing tar.

### DIFF
--- a/lib/tar.js
+++ b/lib/tar.js
@@ -1,8 +1,8 @@
-var exec = require('child_process').exec
+var execFile = require('child_process').execFile
 var rm = require('rimraf')
 
 function parse (tarFile, cb) {
-  exec('tar -tf ' + tarFile, function (err, stdout) {
+  execFile('tar', ['-tf', tarFile], function (err, stdout) {
     if (err) {
       cb(err)
       return


### PR DESCRIPTION
Uses child_process.execFile instead of exec.  Docs say

>  The `child_process.execFile()` function is similar to
>  `child_process.exec()` except that it does not spawn a shell by
>  default. Rather, the specified executable file is spawned directly as
>  a new process making it slightly more efficient than
>  `child_process.exec()`.

Addresses https://github.com/crookedneighbor/npm-unpack/issues/22